### PR TITLE
Correct licence reference in footer

### DIFF
--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -5,7 +5,7 @@
             SQL style guide
         </span> by
         <a xmlns:cc="http://creativecommons.org/ns#"
-           href="https://www.simonholywell.com/?utm_source=sqlstyle.guide&utm_medium=link&utm_campaign=footer-licence"
+           href="https://www.simonholywell.com/?utm_source=sqlstyle.guide-lumoslabs&utm_medium=link&utm_campaign=footer-licence"
            property="cc:attributionName"
            rel="cc:attributionURL">
             Simon Holywell
@@ -15,25 +15,16 @@
             Creative CommonsAttribution-ShareAlike 4.0 International License</a>.
             <br />Based on a work at 
         <a xmlns:dct="http://purl.org/dc/terms/"
-           href="{{ site.url }}"
-           rel="dct:source">
-            {{ site.url }}</a>.
+           href="http://www.sqlstyle.guide"
+           rel="dct:source">www.sqlstyle.guide</a>.
     </p>
     <div class="buttons">
         <ul class="quick-links">
             <li>
-                <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=treffynnon&amp;repo={{ site.domain }}&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112px" height="20px"></iframe>
+                <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=lumoslabs&amp;repo={{ site.domain }}&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112px" height="20px"></iframe>
             </li>
             <li>
-                <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=treffynnon&amp;repo={{ site.domain }}&amp;type=fork&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="98px" height="20px"></iframe>
-            </li>
-        </ul>
-        <ul class="quick-links">
-            <li class="follow-btn">
-                <a href="https://twitter.com/treffynnon" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @treffynnon</a>
-            </li>
-            <li class="tweet-btn">
-                <a href="https://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}" data-text="SQL style guide by @treffynnon: {{ site.description }}" data-dnt="true">Tweet</a>
+                <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=lumoslabs&amp;repo={{ site.domain }}&amp;type=fork&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="98px" height="20px"></iframe>
             </li>
         </ul>
     </div>

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -5,7 +5,7 @@
             SQL style guide
         </span> by
         <a xmlns:cc="http://creativecommons.org/ns#"
-           href="https://www.simonholywell.com/?utm_source=sqlstyle.guide-lumoslabs&utm_medium=link&utm_campaign=footer-licence"
+           href="https://www.simonholywell.com/?utm_source=sqlstyle.guide-{{ site.domain }}&utm_medium=link&utm_campaign=footer-licence"
            property="cc:attributionName"
            rel="cc:attributionURL">
             Simon Holywell

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     <div class="wrap">
         <h1 itemprop="name">SQL Style Guide</h1>
         <p class="author" itemprop="author" itemscope itemtype="http://schema.org/Person">by 
-            <a href="https://www.simonholywell.com/?utm_source=sqlstyle.guide&utm_medium=link&utm_campaign=header" itemprop="url"><span itemprop="name">Simon Holywell</span></a> &middot;
+            <a href="https://www.simonholywell.com/?utm_source={{ site.domain }}-sqlstyle.guide&utm_medium=link&utm_campaign=header" itemprop="url"><span itemprop="name">Simon Holywell</span></a> &middot;
             <a href="https://twitter.com/treffynnon">@Treffynnon</a>
         </p>
         <p class="twitter"><a href="https://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}" data-text="SQL style guide by @treffynnon: {{ site.description }}" data-size="large" data-dnt="true">Tweet</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     <div class="wrap">
         <h1 itemprop="name">SQL Style Guide</h1>
         <p class="author" itemprop="author" itemscope itemtype="http://schema.org/Person">by 
-            <a href="https://www.simonholywell.com/?utm_source={{ site.domain }}-sqlstyle.guide&utm_medium=link&utm_campaign=header" itemprop="url"><span itemprop="name">Simon Holywell</span></a> &middot;
+            <a href="https://www.simonholywell.com/?utm_source=sqlstyle.guide-{{ site.domain }}&utm_medium=link&utm_campaign=header" itemprop="url"><span itemprop="name">Simon Holywell</span></a> &middot;
             <a href="https://twitter.com/treffynnon">@Treffynnon</a>
         </p>
         <p class="twitter"><a href="https://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}" data-text="SQL style guide by @treffynnon: {{ site.description }}" data-size="large" data-dnt="true">Tweet</a>


### PR DESCRIPTION
`{{ site.url }}` refers to the wrong place once you fork the project and host it somewhere else - think I might have to revise the original to hardcode this in as well.